### PR TITLE
Fix incorrect method name and idx.

### DIFF
--- a/src/dex.c
+++ b/src/dex.c
@@ -832,7 +832,7 @@ void dex_readClassDataMethod(const u1 **cursor, dexMethod *pDexMethod) {
 }
 
 // Returns the StringId at the specified index.
-const dexStringId *dex_getStringId(const u1 *dexFileBuf, u2 idx) {
+const dexStringId *dex_getStringId(const u1 *dexFileBuf, u4 idx) {
   CHECK_LT(idx, dex_getStringIdsSize(dexFileBuf));
   dexStringId *dexStringIds = (dexStringId *)(dexFileBuf + dex_getStringIdsOff(dexFileBuf));
   return &dexStringIds[idx];
@@ -882,12 +882,12 @@ const char *dex_getStringDataAndUtf16Length(const u1 *dexFileBuf,
   return (const char *)ptr;
 }
 
-const char *dex_getStringDataAndUtf16LengthByIdx(const u1 *dexFileBuf, u2 idx, u4 *utf16_length) {
+const char *dex_getStringDataAndUtf16LengthByIdx(const u1 *dexFileBuf, u4 idx, u4 *utf16_length) {
   const dexStringId *pDexStringId = dex_getStringId(dexFileBuf, idx);
   return dex_getStringDataAndUtf16Length(dexFileBuf, pDexStringId, utf16_length);
 }
 
-const char *dex_getStringDataByIdx(const u1 *dexFileBuf, u2 idx) {
+const char *dex_getStringDataByIdx(const u1 *dexFileBuf, u4 idx) {
   u4 unicode_length;
   return dex_getStringDataAndUtf16LengthByIdx(dexFileBuf, idx, &unicode_length);
 }
@@ -1009,7 +1009,7 @@ void dex_dumpMethodInfo(const u1 *dexFileBuf,
   const char *typeDesc = dex_getMethodSignature(dexFileBuf, pDexMethodId);
   const char *methodAccessStr = createAccessFlagStr(pDexMethod->accessFlags, kDexAccessForMethod);
 
-  log_dis("   %s_method #%" PRIu32 ": %s %s\n", type, localIdx, methodName, typeDesc);
+  log_dis("   %s_method #%" PRIu32 ": %s %s\n", type, localIdx + pDexMethod->methodIdx, methodName, typeDesc);
   log_dis("    access=%04" PRIx32 " (%s)\n", pDexMethod->accessFlags, methodAccessStr);
   log_dis("    codeOff=%" PRIx32 " (%" PRIu32 ")\n", pDexMethod->codeOff, pDexMethod->codeOff);
 

--- a/src/dex.h
+++ b/src/dex.h
@@ -362,7 +362,7 @@ void dex_readClassDataField(const u1 **, dexField *);
 void dex_readClassDataMethod(const u1 **, dexMethod *);
 
 // Methods to access Dex file primitive types
-const dexStringId *dex_getStringId(const u1 *, u2);
+const dexStringId *dex_getStringId(const u1 *, u4);
 const dexTypeId *dex_getTypeId(const u1 *, u2);
 const dexProtoId *dex_getProtoId(const u1 *, u2);
 const dexFieldId *dex_getFieldId(const u1 *, u4);
@@ -371,8 +371,8 @@ const dexClassDef *dex_getClassDef(const u1 *, u2);
 
 // Helper methods to extract data from Dex primitive types
 const char *dex_getStringDataAndUtf16Length(const u1 *, const dexStringId *, u4 *);
-const char *dex_getStringDataAndUtf16LengthByIdx(const u1 *, u2, u4 *);
-const char *dex_getStringDataByIdx(const u1 *, u2);
+const char *dex_getStringDataAndUtf16LengthByIdx(const u1 *, u4, u4 *);
+const char *dex_getStringDataByIdx(const u1 *, u4);
 const char *dex_getStringByTypeIdx(const u1 *, u2);
 const char *dex_getMethodSignature(const u1 *, const dexMethodId *);
 const char *dex_getProtoSignature(const u1 *, const dexProtoId *);


### PR DESCRIPTION
For some cases, name idx may exceed the range of u2, which will lead to a wrong method name resolve.