### PR TITLE
Fix inconsistency in array declaration

### DIFF
--- a/src/dex_instruction.h
+++ b/src/dex_instruction.h
@@ -275,7 +275,7 @@ s4 dexInstr_getVRegH(u2 *);
 u2 dexInstr_getVRegH_45cc(u2 *);
 u2 dexInstr_getVRegH_4rcc(u2 *);
 bool dexInstr_hasVarArgs(u2 *);
-void dexInstr_getVarArgs(u2 *, u4[]);
+void dexInstr_getVarArgs(u2 *, u4 arg[kMaxVarArgRegs]);
 
 // Set register functions
 void dexInstr_SetVRegA_10x(u2 *, u1);


### PR DESCRIPTION
Fix this error (fedora 36)

```
dex_instruction.c:655:43: error: argument 2 of type ‘u4[kMaxVarArgRegs]’ {aka ‘unsigned int[kMaxVarArgRegs]’} declared as a variable length array [-Werror=vla-parameter]
  655 | void dexInstr_getVarArgs(u2 *code_ptr, u4 arg[kMaxVarArgRegs]) {
      |                                        ~~~^~~~~~~~~~~~~~~~~~~
In file included from dex_instruction.c:23:
dex_instruction.h:278:32: note: previously declared as an ordinary array ‘u4[]’ {aka ‘unsigned int[]’}
  278 | void dexInstr_getVarArgs(u2 *, u4 []);
      |                                ^~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:56: dex_instruction.o] Error 1
```

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wvla-parameter

Thank you