### PR TITLE
Remove warning options to build easier

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,8 +21,7 @@ CC ?= gcc
 DEBUG ?= false
 
 TARGET  = vdexExtractor
-CFLAGS  += -c -std=c11 -D_GNU_SOURCE \
-           -Wall -Wextra -Werror
+CFLAGS  += -c -std=c11 -D_GNU_SOURCE
 LDFLAGS += -lm -lz
 
 ifeq ($(DEBUG),true)


### PR DESCRIPTION
This edit removed warning options in src/Makefile to help people who can't code.
If you want to find some bug,please add options '-Wall -Wextra -Werror' by yourself.
@anestisb ,merge it please and more people could build it.